### PR TITLE
:bug: Corrigindo o serviço de geração de numeros aleatorios

### DIFF
--- a/Services/RandomService.cs
+++ b/Services/RandomService.cs
@@ -1,16 +1,20 @@
 ﻿namespace ProvaPub.Services
 {
-	public class RandomService
-	{
-		int seed;
-		public RandomService()
-		{
-			seed = Guid.NewGuid().GetHashCode();
-		}
-		public int GetRandom()
-		{
-			return new Random(seed).Next(100);
-		}
-
-	}
+    public class RandomService
+    {
+        int seed;
+        public RandomService()
+        {
+            GetNewSeed();
+        }
+        public int GetRandom()
+        {
+            GetNewSeed();
+            return new Random(seed).Next(100);
+        }
+        private void GetNewSeed()
+        {
+            seed = Guid.NewGuid().GetHashCode();
+        }
+    }
 }


### PR DESCRIPTION
- Em vez de gerar um valor para a propriedade _seed_ apenas durante a instanciação do serviço, elaborei um método chamado _GetNewSeed_ que encapsula o código responsável por gerar um novo valor para _seed_. Posteriormente, chamei esse método tanto no momento da invocação do método _GetRandom_ quanto em sua própria definição.